### PR TITLE
Fixed directions for azure section on the home page

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -85,10 +85,10 @@
 				<pre class="command"> $ docker login azure </pre>
 				<li> Create the docker context for Azure. I will call it azureCloud: </li>
 				<pre class="command"> $ docker context create aci azureCloud </pre>
-				<li> Change the docker context to azureCloud: </li>
-				<pre class="command"> $ docker context use azureCloud </pre>
 				<li> Build the doccker image from Docker Hub: </li>
 				<pre class="command"> $ docker build -t username/repo_name . </pre>
+				<li> Change the docker context to azureCloud: </li>
+				<pre class="command"> $ docker context use azureCloud </pre>
 				<li> Run the docker container: </li>
 				<pre class="command"> $ docker run -dp 80:80 username/repo </pre>
 				<p> The port must be 80:80 for it to work in Azure </p>


### PR DESCRIPTION
Put docker build command above the the command to switch to the azure context. 